### PR TITLE
Added downloadFileAsReader function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/FaaSTools/GoStorage
+module github.com/dave-meyer/GoStorage
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dave-meyer/GoStorage
+module github.com/FaaSTools/GoStorage
 
 go 1.18
 

--- a/gostorage/GoStorageProvider.go
+++ b/gostorage/GoStorageProvider.go
@@ -1,5 +1,7 @@
 package gostorage
 
+import "io"
+
 type Provider interface {
 	createBucket(bucketName string, region string)
 	deleteBucket(target GoStorageObject, deleteIfNotEmpty bool)
@@ -9,6 +11,7 @@ type Provider interface {
 
 	uploadFile(target GoStorageObject, sourceFile string)
 	downloadFile(source GoStorageObject, targetFile string)
+	downloadFileAsReader(source GoStorageObject) io.Reader
 	listFilesInBucket(source GoStorageObject) []string
 
 	deleteFile(target GoStorageObject)

--- a/gostorage/aws_storage.go
+++ b/gostorage/aws_storage.go
@@ -70,7 +70,6 @@ func (a AWSStorage) downloadFile(source GoStorageObject, targetFile string) {
 	}
 }
 
-// NEW - TEST
 func (a AWSStorage) downloadFileAsReader(source GoStorageObject) io.Reader {
 	getObjectOutput, err := a.getClientWithRegion(source.Region).GetObject(context.Background(), &aws_s3.GetObjectInput{Bucket: &source.Bucket, Key: &source.Key})
 	checkErr(err, fmt.Sprintf("unable to read from AWS storage object %v, Error: %v", source.Key, err))

--- a/gostorage/aws_storage.go
+++ b/gostorage/aws_storage.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 
@@ -67,6 +68,13 @@ func (a AWSStorage) downloadFile(source GoStorageObject, targetFile string) {
 		err = ioutil.WriteFile(targetFile, data, 0)
 		checkErr(err, fmt.Sprintf("unable to write to file %v, Error: %v", targetFile, err))
 	}
+}
+
+// NEW - TEST
+func (a AWSStorage) downloadFileAsReader(source GoStorageObject) io.Reader {
+	getObjectOutput, err := a.getClientWithRegion(source.Region).GetObject(context.Background(), &aws_s3.GetObjectInput{Bucket: &source.Bucket, Key: &source.Key})
+	checkErr(err, fmt.Sprintf("unable to read from AWS storage object %v, Error: %v", source.Key, err))
+	return getObjectOutput.Body
 }
 
 func (a AWSStorage) listFilesInBucket(source GoStorageObject) []string {

--- a/gostorage/google_storage.go
+++ b/gostorage/google_storage.go
@@ -67,7 +67,6 @@ func (g GoogleStorage) uploadFile(target GoStorageObject, sourceFile string) {
 	checkErr(err, fmt.Sprintf("unable to write to google storage, Error: %v", err))
 }
 
-// NEW - TEST
 func (g GoogleStorage) downloadFileAsReader(source GoStorageObject) io.Reader {
 	reader, err := g.getClient().Bucket(source.Bucket).Object(source.Key).NewReader(context.Background())
 	checkErr(err, fmt.Sprintf("unable to read from google storage object %v, Error: %v", source.Key, err))

--- a/gostorage/google_storage.go
+++ b/gostorage/google_storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 
@@ -64,6 +65,13 @@ func (g GoogleStorage) uploadFile(target GoStorageObject, sourceFile string) {
 	defer writer.Close()
 	_, err = writer.Write(file)
 	checkErr(err, fmt.Sprintf("unable to write to google storage, Error: %v", err))
+}
+
+// NEW - TEST
+func (g GoogleStorage) downloadFileAsReader(source GoStorageObject) io.Reader {
+	reader, err := g.getClient().Bucket(source.Bucket).Object(source.Key).NewReader(context.Background())
+	checkErr(err, fmt.Sprintf("unable to read from google storage object %v, Error: %v", source.Key, err))
+	return reader
 }
 
 func (g GoogleStorage) downloadFile(source GoStorageObject, targetFile string) {

--- a/gostorage/gostorage.go
+++ b/gostorage/gostorage.go
@@ -2,6 +2,7 @@ package gostorage
 
 import (
 	"fmt"
+	"io"
 	"os"
 )
 
@@ -80,6 +81,10 @@ func (s GoStorage) DeleteFileFromString(url string) {
 
 func (s GoStorage) UploadFile(source GoStorageObject) {
 	source.GetProvider(s.Credentials).uploadFile(source, source.LocalFilePath)
+}
+
+func (s GoStorage) DownloadFileAsReader(source GoStorageObject) io.Reader {
+	return source.GetProvider(s.Credentials).downloadFileAsReader(source)
 }
 
 func (s GoStorage) DownloadFile(source GoStorageObject, targetFile string) {


### PR DESCRIPTION
Added a new function 'downloadFileAsReader' for both providers. Unlike the 'downloadFile' function, which stores a file to disk, this function returns an io.Reader for reading the file contents directly. This provides a speedup in some cases.